### PR TITLE
Selbstlöschung von Benutzerkonten (Inhalte bleiben als „mathghost“)

### DIFF
--- a/mathefragen/apps/review/migrations/0001_initial.py
+++ b/mathefragen/apps/review/migrations/0001_initial.py
@@ -17,29 +17,32 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name='Review',
-            fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('hash_id', models.CharField(db_index=True, default=mathefragen.apps.core.models.create_default_hash, editable=False, max_length=30)),
-                ('idate', models.DateTimeField(auto_now_add=True, db_index=True, verbose_name='created at')),
-                ('udate', models.DateTimeField(auto_now=True, verbose_name='changed at')),
-                ('text', models.TextField()),
-                ('relation_source', models.CharField(blank=True, choices=[('helper', 'Hat mir geholfen'), ('worked_together', 'Zusammen gearbeitet'), ('studied_together', 'Zusammen studiert')], default='', max_length=50)),
-                ('soft_deleted', models.BooleanField(default=False)),
-                ('given_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='given_reviews', to=settings.AUTH_USER_MODEL)),
-                ('given_to', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='received_reviews', to=settings.AUTH_USER_MODEL)),
-                ('hashtags', models.ManyToManyField(db_table='user_review_hashtags', related_name='confirmed_hashtags', to='hashtag.HashTag')),
-                ('source_question', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='reviews_from_question', to='question.Question')),
+        # Die `user_review`-Tabelle wird physisch von der user-App angelegt
+        # (user.0001_squashed) — das Review-Modell ist nur aus der user-App in
+        # die review-App umgezogen. Daher hier nur Modell-State registrieren,
+        # ohne die Tabelle erneut zu erstellen (sonst "table already exists").
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name='Review',
+                    fields=[
+                        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                        ('hash_id', models.CharField(db_index=True, default=mathefragen.apps.core.models.create_default_hash, editable=False, max_length=30)),
+                        ('idate', models.DateTimeField(auto_now_add=True, db_index=True, verbose_name='created at')),
+                        ('udate', models.DateTimeField(auto_now=True, verbose_name='changed at')),
+                        ('text', models.TextField()),
+                        ('relation_source', models.CharField(blank=True, choices=[('helper', 'Hat mir geholfen'), ('worked_together', 'Zusammen gearbeitet'), ('studied_together', 'Zusammen studiert')], default='', max_length=50)),
+                        ('soft_deleted', models.BooleanField(default=False)),
+                        ('given_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='given_reviews', to=settings.AUTH_USER_MODEL)),
+                        ('given_to', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='received_reviews', to=settings.AUTH_USER_MODEL)),
+                        ('hashtags', models.ManyToManyField(db_table='user_review_hashtags', related_name='confirmed_hashtags', to='hashtag.HashTag')),
+                        ('source_question', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='reviews_from_question', to='question.Question')),
+                    ],
+                    options={
+                        'db_table': 'user_review',
+                    },
+                ),
             ],
-            options={
-                'db_table': 'user_review',
-            },
+            database_operations=[],
         ),
     ]
-
-    def apply(self, project_state, schema_editor, collect_sql=False):
-        return project_state
-
-    def unapply(self, project_state, schema_editor, collect_sql=False):
-        return project_state

--- a/mathefragen/apps/user/api/views.py
+++ b/mathefragen/apps/user/api/views.py
@@ -212,12 +212,15 @@ def user_detail_get(request, pk):
 @permission_classes((IsAuthenticated,))
 @authentication_classes((JWTAuthentication,))
 def user_detail_delete(request, pk):
-    try:
-        user = User.objects.get(pk=pk)
-    except User.DoesNotExist:
-        return Response(status=status.HTTP_404_NOT_FOUND)
+    # Nur das eigene Konto darf gelöscht werden.
+    if request.user.pk != pk:
+        return Response(status=status.HTTP_403_FORBIDDEN)
 
-    user.delete()
+    profile = request.user.profile
+
+    # Inhalte erhalten: auf mathghost umhängen, dann Konto löschen.
+    profile.transfer_content_to_ghost()
+    profile.delete()  # post_delete-Signal löscht den zugehörigen User
 
     stats = request.stats
     if stats:

--- a/mathefragen/apps/user/migrations/0023_delete_review.py
+++ b/mathefragen/apps/user/migrations/0023_delete_review.py
@@ -10,7 +10,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.DeleteModel(
-            name='Review',
+        # Das Review-Modell ist in die review-App umgezogen. Nur aus dem State
+        # der user-App entfernen — die physische `user_review`-Tabelle bleibt
+        # erhalten (sie wird jetzt vom Review-Modell der review-App genutzt).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.DeleteModel(
+                    name='Review',
+                ),
+            ],
+            database_operations=[],
         ),
     ]

--- a/mathefragen/apps/user/models.py
+++ b/mathefragen/apps/user/models.py
@@ -26,6 +26,10 @@ from mathefragen.apps.news.models import ReleaseNote
 from mathefragen.apps.playlist.models import Playlist
 from mathefragen.apps.question.models import Question, Answer
 
+# Geteilter Sammel-User, der Fragen/Antworten/Kommentare gelöschter Konten
+# übernimmt, damit Inhalte erhalten bleiben (Username wird durch ihn ersetzt).
+GHOST_USERNAME = 'mathghost'
+
 
 class PostalCode(models.Model):
     code = models.IntegerField(db_index=True)
@@ -294,6 +298,24 @@ class Profile(Base):
 
     def close_user_questions(self):
         self.user.user_questions.update(soft_deleted=True)
+
+    def transfer_content_to_ghost(self):
+        """Hängt Fragen, Antworten und Kommentare auf den geteilten
+        ``mathghost``-User um, damit die Inhalte beim Löschen des Kontos
+        erhalten bleiben. Entfernt dabei zugleich die IP-Spur."""
+        ghost, _ = User.objects.get_or_create(
+            username=GHOST_USERNAME,
+            defaults={'is_active': False},
+        )
+        user = self.user
+        for queryset in (
+            user.user_questions,
+            user.user_answers,
+            user.user_answer_comments,
+            user.user_question_comments,
+        ):
+            queryset.update(user=ghost, source_ip='192.168.0.1')
+        return ghost
 
     def has_confirmed_email(self):
         return 'confirmed' in self.confirm_hash

--- a/mathefragen/apps/user/tests/test_delete_account.py
+++ b/mathefragen/apps/user/tests/test_delete_account.py
@@ -1,0 +1,105 @@
+from rest_framework import status
+
+from django.contrib.auth.models import User
+from django.shortcuts import reverse
+from django.test import TestCase
+
+from mathefragen.apps.user.models import GHOST_USERNAME
+from mathefragen.apps.question.models import (
+    Question, Answer, AnswerComment, QuestionComment
+)
+
+
+class SelfDeleteWebViewTestCase(TestCase):
+    """Eingeloggter User löscht sein Konto über das Profil; Fragen/Antworten/
+    Kommentare werden auf den geteilten ``mathghost``-User umgehängt."""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username='to_be_deleted', email='bye@email.com', is_active=True
+        )
+        self.user.set_password('something_secret')
+        self.user.save()
+
+        self.question = Question.objects.create(
+            title='Meine Frage', text='Meine Frage', user_id=self.user.id
+        )
+        self.answer = Answer.objects.create(
+            question_id=self.question.id, text='Meine Antwort', user_id=self.user.id
+        )
+        self.answer_comment = AnswerComment.objects.create(
+            answer_id=self.answer.id, text='Mein Antwort-Kommentar', user_id=self.user.id
+        )
+        self.question_comment = QuestionComment.objects.create(
+            question_id=self.question.id, text='Mein Frage-Kommentar', user_id=self.user.id
+        )
+
+    def test_self_delete_reassigns_content_to_mathghost(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse('delete_my_account'))
+        self.assertEqual(response.status_code, 302)
+
+        # account is gone
+        self.assertFalse(User.objects.filter(pk=self.user.pk).exists())
+
+        # ghost collector exists and owns the content
+        ghost = User.objects.get(username=GHOST_USERNAME)
+        self.question.refresh_from_db()
+        self.answer.refresh_from_db()
+        self.answer_comment.refresh_from_db()
+        self.question_comment.refresh_from_db()
+
+        self.assertEqual(self.question.user_id, ghost.id)
+        self.assertEqual(self.answer.user_id, ghost.id)
+        self.assertEqual(self.answer_comment.user_id, ghost.id)
+        self.assertEqual(self.question_comment.user_id, ghost.id)
+
+        # personal IP trace removed from reassigned content
+        self.assertEqual(self.answer.source_ip, '192.168.0.1')
+
+    def test_delete_account_get_is_not_allowed(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('delete_my_account'))
+        self.assertEqual(response.status_code, 405)
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+
+    def test_settings_page_renders_delete_modal(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('profile_settings', kwargs={'pk': self.user.id})
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('delete_account_modal', content)
+        self.assertIn('confirm_delete_account', content)
+        # confirmation is gated on typing the own username
+        self.assertIn('data-username="%s"' % self.user.username, content)
+
+
+class ApiDeleteOwnershipTestCase(TestCase):
+    """Die API darf nur das eigene Konto löschen, nicht fremde."""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username='api_self', email='self@email.com', is_active=True
+        )
+        self.user.set_password('something_secret')
+        self.user.save()
+        self.other = User.objects.create(
+            username='api_other', email='other@email.com', is_active=True
+        )
+
+        token_response = self.client.post(
+            reverse('api_login_me'),
+            {'login_id': self.user.username, 'login_pwd': 'something_secret'},
+        )
+        self.token = token_response.json().get('token')
+
+    def test_cannot_delete_other_user(self):
+        response = self.client.delete(
+            reverse('api_user_detail_delete', kwargs={'pk': self.other.id}),
+            HTTP_AUTHORIZATION='JWT {}'.format(self.token),
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(User.objects.filter(pk=self.other.pk).exists())

--- a/mathefragen/apps/user/views.py
+++ b/mathefragen/apps/user/views.py
@@ -18,6 +18,7 @@ from django.http import StreamingHttpResponse
 from django.shortcuts import render, reverse, redirect, HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic import FormView, CreateView
 
 from mathefragen.apps.core.utils import (
@@ -1227,14 +1228,16 @@ def inbox(request, pk):
 
 
 @login_required
+@require_POST
 def delete_account(request):
-    user = request.user
+    profile = request.user.profile
 
-    # later do some other cleanups
-    user.delete()
+    # Inhalte erhalten: auf mathghost umhängen, dann Konto löschen.
+    profile.transfer_content_to_ghost()
+    profile.delete()  # post_delete-Signal löscht den zugehörigen User
 
-    stats = request.stats
-    stats.update_total_users()
+    if request.stats:
+        request.stats.update_total_users()
 
     return redirect('%s?account_deleted=1' % reverse('index'))
 

--- a/mathefragen/templates/base.html
+++ b/mathefragen/templates/base.html
@@ -129,7 +129,6 @@
             }
             const saveChannelSuggestionUrl = '{% url "save_channel_suggestion" %}';
             const sendFeedbackUrl = '{% url "send_feedback" %}';
-            const deleteAccountUrl = "{% url 'delete_my_account' %}";
             const loading_img_src = '{% static "images/loading.gif" %}';
             const isMobile = {% if request.user_agent.is_mobile %}true{% else %}false{% endif %};
             const askToCompleteProfile = {% if request.user.is_authenticated and request.user.profile.should_complete_profile %}true{% else %}false{% endif %};
@@ -714,11 +713,10 @@
                     $('#feedback_modal').modal('show');
                 });
 
-                $('.delete-account-completely').on('click', function(){
-                    var delete_confirmed = window.confirm('Möchtest du wirklich dein Benutzerkonto vollständig löschen?');
-                    if (delete_confirmed) {
-                        window.location.href = deleteAccountUrl;
-                    }
+                // Lösch-Button erst aktivieren, wenn der eigene Benutzername eingetippt wurde.
+                $('#delete_account_username').on('input', function(){
+                    var expected = String($(this).data('username'));
+                    $('#confirm_delete_account').prop('disabled', $(this).val() !== expected);
                 });
 
                 $('.fa-search').on('click', function(){

--- a/mathefragen/templates/user/tabs/settings.html
+++ b/mathefragen/templates/user/tabs/settings.html
@@ -222,7 +222,7 @@
     </div>
 </div>
 
-<div class="card mt-4 mb-5 ml-4 mr-4">
+<div class="card mt-4 mb-5 ml-4 mr-4 border-danger">
     <div class="card-header text-danger text-bold">
         Gefahrenzone
     </div>
@@ -231,10 +231,63 @@
             Hier kannst du dein Benutzerkonto vollständig löschen.
             <b>Das Löschen eines Benutzerkontos kann nicht rückgängig gemacht werden.</b>
         </p>
+        <p class="card-text text-muted font14">
+            <i class="fas fa-ghost"></i>
+            Deine Fragen, Antworten und Kommentare bleiben erhalten und werden
+            künftig dem Nutzer <b>mathghost</b> zugeordnet.
+        </p>
 
-        <button type="button" class="btn btn-danger delete-account-completely">
-            Jetzt mein Benutzerkonto vollständig löschen!
+        <button type="button" class="btn btn-danger"
+                data-toggle="modal" data-target="#delete_account_modal">
+            Mein Benutzerkonto löschen …
         </button>
 
+    </div>
+</div>
+
+<div class="modal fade" id="delete_account_modal" tabindex="-1" role="dialog"
+     aria-labelledby="delete_account_modal_label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content border-danger">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title" id="delete_account_modal_label">
+                    <i class="fas fa-exclamation-triangle"></i>
+                    Benutzerkonto wirklich löschen?
+                </h5>
+                <button type="button" class="close text-white" data-dismiss="modal" aria-label="Schließen">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body font14">
+                <p>
+                    Dein Konto und deine persönlichen Daten werden
+                    <b>unwiderruflich</b> gelöscht. Dies kann nicht rückgängig
+                    gemacht werden.
+                </p>
+                <p class="text-muted">
+                    <i class="fas fa-ghost"></i>
+                    Deine Fragen, Antworten und Kommentare bleiben erhalten und
+                    werden dem Nutzer <b>mathghost</b> zugeordnet.
+                </p>
+                <label for="delete_account_username" class="text-bold mb-1">
+                    Tippe zur Bestätigung deinen Benutzernamen
+                    <code>{{ request.user.username }}</code> ein:
+                </label>
+                <input type="text" class="form-control" id="delete_account_username"
+                       data-username="{{ request.user.username }}" autocomplete="off"
+                       placeholder="{{ request.user.username }}">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                    Abbrechen
+                </button>
+                <form method="post" action="{% url 'delete_my_account' %}" class="m-0">
+                    {% csrf_token %}
+                    <button type="submit" id="confirm_delete_account" class="btn btn-danger" disabled>
+                        Konto endgültig löschen
+                    </button>
+                </form>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Was & Warum

Eingeloggte User konnten sich bisher nicht zuverlässig selbst löschen. Dieser PR ermöglicht die Selbstlöschung über die Profil-Einstellungen („Gefahrenzone"). Fragen, Antworten und Kommentare bleiben erhalten und werden dem geteilten Platzhalter-User **`mathghost`** zugeordnet (Reddit-Stil: Username wird ersetzt). Konto + persönliche Daten werden hart gelöscht (DSGVO-konform).

## Änderungen

**Backend**
- `Profile.transfer_content_to_ghost()` + `GHOST_USERNAME`: hängt Fragen/Antworten/Kommentare auf `mathghost` um, entfernt IP-Spur.
- `delete_account` view jetzt **POST-only** (`@require_POST`) → Helper → `profile.delete()` (post_delete-Signal entfernt User). `request.stats` gegen `None` geguarded.
- API `user_detail_delete`: **Ownership-Check** (`pk != request.user.pk` → 403) + gleicher Helper. Vorher konnte jeder eingeloggte User jedes Konto löschen (**Sicherheitslücke**).

**Migration-Fix (eigentliche Ursache)**
- Das `Review`-Modell zog von der `user`-App in die `review`-App um. `user.0023` dropte die `user_review`-Tabelle, `review.0001` war ein No-Op → auf frischen DBs existierte die Tabelle nie, jeder User-Delete crashte im Cascade (`no such table: user_review`).
- Beide Migrationen jetzt **state-only** (`SeparateDatabaseAndState`): Tabelle wird einmal erstellt, nie gedroppt. Produktion unberührt (bereits angewandte Migrationen laufen nie erneut). Behebt zugleich den bestehenden roten `test_user_delete`.

**Frontend**
- `window.confirm`-GET-Flow ersetzt durch Bootstrap-Danger-Modal in der Gefahrenzone. Lösch-Button bleibt deaktiviert, bis der eigene Benutzername eingetippt wird; Submit ist ein CSRF-geschützter POST.

## Tests
Neue `test_delete_account`: Reassign→mathghost, POST-only (GET→405), API-Ownership (403), Settings-Seite rendert Modal.

```
DEBUG=True poetry run python manage.py test mathefragen.apps.user.tests.test_delete_account
# Ran 4 tests OK
```

Regressions-Check (Baseline vs. Branch): keine neuen Failures; `test_user_delete` von rot→grün. Übrige Failures (`test_a_register`, `test_answer_delete`, `test_question_delete`, `test_number_answers ×3`) sind pre-existing und unverändert.

## Hinweise
- `mathghost` muss in der Produktions-DB existieren (tut er bereits); auf frischen DBs wird er bei Bedarf via `get_or_create` (login-deaktiviert) angelegt.
- `mathghost` taucht dadurch potenziell in Statistiken/Bestenlisten auf — bestehendes Verhalten, bewusst nicht angefasst.

## Manuelle Verifikation
`docker compose up` → als normaler User Frage+Antwort erstellen → Profil → Einstellungen → Gefahrenzone → Benutzername eintippen → löschen. Danach: Konto weg, Beiträge zeigen „mathghost".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGmiqYjPC3cNRtN7j3oZym