### PR TITLE
Wire global stats modal to real data

### DIFF
--- a/mathefragen/apps/stats/tests.py
+++ b/mathefragen/apps/stats/tests.py
@@ -1,3 +1,120 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from django.test import Client, TestCase
+from django.shortcuts import reverse
+from django.utils import timezone
+from django.contrib.auth.models import User
+
+from mathefragen.apps.question.models import (
+    Question,
+    Answer,
+    QuestionComment,
+    AnswerComment,
+)
+
+
+class DeeperStatsTestCase(TestCase):
+    """
+    Verifies the /v1/stats/numbers/deeper/ endpoint that powers the
+    global stats modal (templates/modals/global_stats.html).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+
+        cls.asker = User.objects.create(username='asker', email='asker@mail.com', is_active=True)
+        cls.helper_a = User.objects.create(username='helper_a', email='a@mail.com', is_active=True)
+        cls.helper_b = User.objects.create(username='helper_b', email='b@mail.com', is_active=True)
+
+        # Two recent questions (within all ranges). q1 is the more upvoted one.
+        cls.q1 = Question.objects.create(
+            user=cls.asker, title='Frage 1', text='t1',
+            number_answers=2, vote_points=10, views=100,
+        )
+        cls.q2 = Question.objects.create(
+            user=cls.asker, title='Frage 2', text='t2',
+            number_answers=1, vote_points=5, views=50,
+        )
+        # Unanswered + no votes -> counts toward total questions but not answered/top.
+        cls.q3 = Question.objects.create(
+            user=cls.asker, title='Frage 3', text='t3',
+            number_answers=0, vote_points=0, views=5,
+        )
+
+        # helper_b is created last (higher id) but gives more answers, so it
+        # must rank first. This guards against ranking by id instead of by
+        # answer count.
+        Answer.objects.create(user=cls.helper_a, question=cls.q1, text='a1')
+        Answer.objects.create(user=cls.helper_b, question=cls.q2, text='a2')
+        Answer.objects.create(user=cls.helper_b, question=cls.q1, text='a3')
+
+        QuestionComment.objects.create(user=cls.asker, question=cls.q1, text='qc')
+        AnswerComment.objects.create(
+            user=cls.asker,
+            answer=Answer.objects.first(),
+            text='ac',
+        )
+
+    def _get(self, time_range):
+        response = self.client.get(
+            reverse('deeper_stats'), {'range': time_range}
+        )
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.content)
+
+    def test_counts_within_30_day_range(self):
+        payload = self._get('30')
+
+        self.assertEqual(payload['questions_num'], 3)
+        self.assertEqual(payload['answers_num'], 3)
+        self.assertEqual(payload['comments_num'], 2)
+
+        # 2 of 3 questions answered -> 66.x %
+        self.assertGreater(payload['percentage_answers'], 60)
+        self.assertLess(payload['percentage_answers'], 70)
+
+    def test_top_questions_sorted_by_votes(self):
+        payload = self._get('30')
+
+        titles = [q['title'] for q in payload['top_3_questions']]
+        self.assertEqual(titles, ['Frage 1', 'Frage 2'])
+        self.assertEqual(payload['top_3_questions'][0]['views'], 100)
+        self.assertEqual(payload['top_3_questions'][0]['answers'], 2)
+
+    def test_top_helpers_sorted_by_answer_count(self):
+        payload = self._get('30')
+
+        usernames = [h['username'] for h in payload['top_3_helpers']]
+        # helper_b (2 answers, higher id) must rank before helper_a (1 answer).
+        self.assertEqual(usernames, ['helper_b', 'helper_a'])
+
+    def test_range_filtering_excludes_old_records(self):
+        old = timezone.now() - timezone.timedelta(days=400)
+        # Backdate everything (auto_now_add can't be set at create time).
+        Question.objects.update(idate=old)
+        Answer.objects.update(idate=old)
+        QuestionComment.objects.update(idate=old)
+        AnswerComment.objects.update(idate=old)
+
+        recent = self._get('30')
+        self.assertEqual(recent['questions_num'], 0)
+        self.assertEqual(recent['answers_num'], 0)
+        self.assertEqual(recent['comments_num'], 0)
+        self.assertEqual(recent['top_3_helpers'], [])
+        self.assertEqual(recent['top_3_questions'], [])
+
+        total = self._get('total')
+        self.assertEqual(total['questions_num'], 3)
+        self.assertEqual(total['answers_num'], 3)
+
+    def test_empty_database_returns_zeroes(self):
+        Question.objects.all().delete()
+        Answer.objects.all().delete()
+        QuestionComment.objects.all().delete()
+        AnswerComment.objects.all().delete()
+
+        payload = self._get('30')
+        self.assertEqual(payload['questions_num'], 0)
+        self.assertEqual(payload['percentage_answers'], 0)
+        self.assertEqual(payload['top_3_helpers'], [])

--- a/mathefragen/apps/stats/views.py
+++ b/mathefragen/apps/stats/views.py
@@ -100,8 +100,14 @@ def deeper_stats(request):
     top_3_helper_ids = Profile.get_helper_ids(
         from_date=since_date, to_date=timezone.now(), slice_number=3
     )
-    top_3_helpers = User.objects.filter(id__in=top_3_helper_ids)
-    for u in top_3_helpers:
+    helpers_by_id = User.objects.in_bulk(top_3_helper_ids)
+    # get_helper_ids returns the ids already ranked by answer count, so we
+    # iterate over that list to preserve the ranking (a plain filter(id__in=)
+    # would return them in arbitrary db order).
+    for helper_id in top_3_helper_ids:
+        u = helpers_by_id.get(helper_id)
+        if u is None:
+            continue
         helper_dict = {
             "username": u.username,
             "url": u.profile.get_absolute_url(),

--- a/mathefragen/templates/index.html
+++ b/mathefragen/templates/index.html
@@ -372,6 +372,85 @@
                 $('#id_global_stats').modal('show');
             });
 
+            (function () {
+                var statsUrl = "{% url 'deeper_stats' %}";
+
+                function renderHelpers($container, helpers) {
+                    $container.empty();
+                    if (!helpers || !helpers.length) {
+                        $container.append(
+                            $('<p>').addClass('promotion_p font11 grey_text').text('Noch keine Daten.')
+                        );
+                        return;
+                    }
+                    helpers.forEach(function (h) {
+                        var $link = $('<a>')
+                            .addClass('link_color light_bold')
+                            .attr('href', h.url || '#')
+                            .text(h.username || '');
+                        if (h.verified) {
+                            $link.append(' ').append($('<i>').addClass('fa font11 fa-badge-check'));
+                        }
+                        var $info = $('<small>').addClass('font11').text((h.answers || 0) + ' mal geholfen');
+                        $container.append(
+                            $('<p>').addClass('promotion_p').append($link).append('<br>').append($info)
+                        );
+                    });
+                }
+
+                function renderQuestions($container, questions) {
+                    $container.empty();
+                    if (!questions || !questions.length) {
+                        $container.append(
+                            $('<p>').addClass('promotion_p font11 grey_text').text('Noch keine Daten.')
+                        );
+                        return;
+                    }
+                    questions.forEach(function (q) {
+                        var $link = $('<a>')
+                            .addClass('link_color light_bold')
+                            .attr('href', q.url || '#')
+                            .text(q.title || '');
+                        var $info = $('<small>').addClass('font11')
+                            .text((q.answers || 0) + ' Antworten, ' + (q.views || 0) + ' Views');
+                        $container.append(
+                            $('<p>').addClass('promotion_p').append($link).append('<br>').append($info)
+                        );
+                    });
+                }
+
+                function loadPane($pane) {
+                    if (!$pane.length || $pane.data('loaded') || $pane.data('loading')) {
+                        return;
+                    }
+                    $pane.data('loading', true);
+                    $.getJSON(statsUrl, {range: $pane.data('range')})
+                        .done(function (data) {
+                            $pane.find('.js-stats-percentage').text(Math.round(data.percentage_answers || 0));
+                            $pane.find('.js-stats-questions').text(data.questions_num || 0);
+                            $pane.find('.js-stats-answers').text(data.answers_num || 0);
+                            $pane.find('.js-stats-comments').text(data.comments_num || 0);
+                            renderHelpers($pane.find('.js-stats-helpers'), data.top_3_helpers);
+                            renderQuestions($pane.find('.js-stats-questions-list'), data.top_3_questions);
+                            $pane.data('loaded', true);
+                        })
+                        .fail(function () {
+                            $pane.find('.js-stats-percentage, .js-stats-questions, .js-stats-answers, .js-stats-comments').text('–');
+                        })
+                        .always(function () {
+                            $pane.data('loading', false);
+                        });
+                }
+
+                $('#id_global_stats').on('shown.bs.modal', function () {
+                    loadPane($(this).find('.js-stats-pane.active'));
+                });
+
+                $('#id_global_stats').on('shown.bs.tab', 'a[data-toggle="tab"]', function (e) {
+                    loadPane($($(e.target).attr('href')));
+                });
+            })();
+
             $('.main_question_button_clck').on('click', function (e) {
                 // prevent default
                 e.preventDefault();

--- a/mathefragen/templates/modals/global_stats.html
+++ b/mathefragen/templates/modals/global_stats.html
@@ -26,81 +26,21 @@
 
                 <!-- Tab panes -->
                 <div class="tab-content">
-                    <div role="tabpanel" class="tab-pane active" id="thirty_day_tab_stats">
-                        <div style="padding-top: 30px;">
-                            <h6>
-                                <span id="tab_stats_30_percentage">95</span>% der Fragen sind beantwortet
-                            </h6>
-                            <div class="row" style="padding-top: 5px">
-                                <div class="col">
-                                    <span class="font13 grey_text">Fragen</span>
-                                    <h5 id="tab_stats_30_questions_num">3444</h5>
-                                </div>
-                                <div class="col">
-                                    <span class="font13 grey_text">Anworten</span>
-                                    <h5 id="tab_stats_30_answers_num">3444</h5>
-                                </div>
-                                <div class="col">
-                                    <span class="font13 grey_text">Kommentare</span>
-                                    <h5 id="tab_stats_30_comments_num">3444</h5>
-                                </div>
-                            </div>
-                        </div>
-                        <div style="margin-top: 30px">
-                            <h6>Top 3 Helfer</h6>
-                            <div class="" style="padding-top: 5px">
-                                <p class="promotion_p">
-                                    <a href="#helper.get_absolute_url" class="link_color light_bold">
-                                        helper.username
-                                        <i class="fa font11 fa-badge-check"></i>
-                                    </a>
-                                    <br>
-                                    <small class="font11">
-                                        helper.answers_this_week|cool_number mal geholfen
-                                    </small>
-                                </p>
-                                <p class="promotion_p">
-                                    <a href="#helper.get_absolute_url" class="link_color light_bold">
-                                        helper.username
-                                        <i class="fa font11 fa-badge-check"></i>
-                                    </a>
-                                    <br>
-                                    <small class="font11">
-                                        helper.answers_this_week|cool_number mal geholfen
-                                    </small>
-                                </p>
-                            </div>
-                        </div>
-                        <div style="margin-top: 30px">
-                            <h6>Top 3 Fragen</h6>
-                            <div class="" style="padding-top: 10px">
-                                <p class="promotion_p">
-                                    <a href="#helper.get_absolute_url" class="link_color light_bold">
-                                        Frage text title
-                                    </a>
-                                    <br>
-                                    <small class="font11">
-                                        3 Antworten, 23 Views
-                                    </small>
-                                </p>
-                                <p class="promotion_p">
-                                    <a href="#helper.get_absolute_url" class="link_color light_bold">
-                                        Frage text title
-                                    </a>
-                                    <br>
-                                    <small class="font11">
-                                        3 Antworten, 23 Views
-                                    </small>
-                                </p>
-                            </div>
-                        </div>
-
+                    {% comment %}
+                    The three panes share the same markup. Data is fetched from
+                    {% url 'deeper_stats' %} per range and injected by the JS in
+                    index.html (extra_js_bottom block), scoped via the
+                    js-stats-pane class and data-range attribute.
+                    {% endcomment %}
+                    <div role="tabpanel" class="tab-pane active js-stats-pane" id="thirty_day_tab_stats"
+                         data-range="30">
+                        {% include 'modals/includes/global_stats_pane.html' %}
                     </div>
-                    <div role="tabpanel" class="tab-pane" id="week_tab_stats">
-
+                    <div role="tabpanel" class="tab-pane js-stats-pane" id="week_tab_stats" data-range="7">
+                        {% include 'modals/includes/global_stats_pane.html' %}
                     </div>
-                    <div role="tabpanel" class="tab-pane" id="total_tab_stats">
-
+                    <div role="tabpanel" class="tab-pane js-stats-pane" id="total_tab_stats" data-range="total">
+                        {% include 'modals/includes/global_stats_pane.html' %}
                     </div>
                 </div>
             </div>

--- a/mathefragen/templates/modals/includes/global_stats_pane.html
+++ b/mathefragen/templates/modals/includes/global_stats_pane.html
@@ -1,0 +1,36 @@
+{% comment %}
+Single stats pane body. Reused for the 30-day, week and total tabs.
+All dynamic values carry a js-* class and start empty / as a spinner; the
+JS in index.html fills them from the deeper_stats endpoint.
+{% endcomment %}
+<div style="padding-top: 30px;">
+    <h6>
+        <span class="js-stats-percentage">…</span>% der Fragen sind beantwortet
+    </h6>
+    <div class="row" style="padding-top: 5px">
+        <div class="col">
+            <span class="font13 grey_text">Fragen</span>
+            <h5 class="js-stats-questions">…</h5>
+        </div>
+        <div class="col">
+            <span class="font13 grey_text">Antworten</span>
+            <h5 class="js-stats-answers">…</h5>
+        </div>
+        <div class="col">
+            <span class="font13 grey_text">Kommentare</span>
+            <h5 class="js-stats-comments">…</h5>
+        </div>
+    </div>
+</div>
+<div style="margin-top: 30px">
+    <h6>Top 3 Helfer</h6>
+    <div class="js-stats-helpers" style="padding-top: 5px">
+        <p class="promotion_p font11 grey_text js-stats-helpers-empty">Noch keine Daten.</p>
+    </div>
+</div>
+<div style="margin-top: 30px">
+    <h6>Top 3 Fragen</h6>
+    <div class="js-stats-questions-list" style="padding-top: 10px">
+        <p class="promotion_p font11 grey_text js-stats-questions-empty">Noch keine Daten.</p>
+    </div>
+</div>


### PR DESCRIPTION
## Problem

The global stats modal (opened by clicking the answered-percentage on the index page) showed placeholder data — see screenshot below the report. It was a static mockup:

- All three counters hardcoded to `3444`
- Literal strings `helper.username`, `helper.answers_this_week|cool_number mal geholfen`, `Frage text title`, `3 Antworten, 23 Views`
- The **Woche** and **Insgesamt** tabs were completely empty

## What this PR does

The backend already had a fully-built endpoint — `deeper_stats` (`GET /v1/stats/numbers/deeper/?range=30|7|total`) returning percentage answered, question/answer/comment counts, top 3 helpers and top 3 questions. It was just never connected to the UI.

**Backend** (`apps/stats/`)
- Fix a latent ordering bug: top-3-helpers was built with `filter(id__in=ranked_ids)`, which returns rows in arbitrary db order and discarded the answer-count ranking from `get_helper_ids`. Now iterates the ranked ids via `in_bulk`.
- Add `DeeperStatsTestCase` (5 tests): counts, percentage, top-question ordering, top-helper ordering, time-range filtering, empty DB. The endpoint had **zero** test coverage before.

**Frontend** (`templates/`)
- Replace the mockup modal with three identical panes (30 days / week / total) sharing an include (`modals/includes/global_stats_pane.html`).
- jQuery fetches `deeper_stats` per range, **lazily**: active pane on modal open, other panes on first tab switch, each fetched once.
- Helper/question lists are built with DOM/text nodes, so user-supplied titles and usernames can't inject markup (XSS-safe).

## Verification

- `python manage.py test mathefragen.apps.stats` → 5/5 pass
- `python manage.py check` → no issues
- Templates parse via `get_template` (full include tree + `{% url %}`)

⚠️ Not yet verified live in a browser (needs a running server + seeded DB). The JS is structurally simple but a quick manual smoke test before merge is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)