### PR TITLE
Admin-Moderations-Buttons auf Fragen-Seite (Verstecken/Löschen)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-admin-question-moderation-buttons.md
+++ b/docs/superpowers/plans/2026-07-14-admin-question-moderation-buttons.md
@@ -1,0 +1,425 @@
+# Admin Control Buttons für Fragen-Moderation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admins und Moderatoren können eine Frage direkt auf der Detailseite verstecken/einblenden und löschen — über ein Moderations-Panel mit zwei Buttons.
+
+**Architecture:** Eine gebündelte Berechtigungsmethode `Profile.can_moderate()` (`is_staff OR Badge-Moderator`) gated Template-Panel und View-Aktionen identisch. Verstecken toggelt `Question.is_active`; Löschen nutzt den bestehenden `delete_question`-Endpoint mit erweiterter Autorisierung. Keine neuen Model-Felder, keine Migration.
+
+**Tech Stack:** Django 5.x, function-based views, Django-Templates (Bootstrap), Django-`TestCase` mit SQLite.
+
+## Global Constraints
+
+- Sprache im UI: Deutsch (Umlaute korrekt: ö, ü, ä, ß).
+- Tests laufen mit SQLite (automatisch via `sys.argv`); Kommando: `python manage.py test <dotted.path> -v 2`.
+- Session-Login in Tests via `self.client.force_login(user)` (nicht JWT — die Views sind session-basiert).
+- Berechtigung überall über `request.user.profile.can_moderate()` (View) bzw. `request.user.profile.can_moderate` (Template) — kein direktes `is_staff`/`is_moderator` an neuen Stellen.
+- Neue/erweiterte Endpoints folgen dem Bestandsmuster: `@login_required` + Inline-Re-Check + Redirect (GET-Link, kein CSRF — bewusster, dokumentierter Tradeoff).
+- Commit-Trailer an jede Commit-Message anhängen:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01DQq5ReKsk6FnLTysGngmcz
+  ```
+
+---
+
+## File Structure
+
+| Datei | Verantwortung |
+|---|---|
+| `mathefragen/apps/user/models.py` | `Profile.can_moderate()` — einzige Berechtigungsquelle |
+| `mathefragen/apps/user/tests/test_permissions.py` (neu) | Tests für `can_moderate()` |
+| `mathefragen/apps/question/views.py` | neue View `toggle_question_visibility`; `delete_question`-Gate erweitern |
+| `mathefragen/apps/question/urls.py` | Route für `toggle_question_visibility` |
+| `mathefragen/apps/question/tests/test_moderation.py` (neu) | View- + Template-Integrationstests |
+| `mathefragen/templates/question/question_content.html` | Moderations-Panel |
+
+---
+
+## Task 1: `Profile.can_moderate()`
+
+**Files:**
+- Modify: `mathefragen/apps/user/models.py` (nahe `is_moderator`, ~Zeile 410)
+- Test: `mathefragen/apps/user/tests/test_permissions.py` (neu)
+
+**Interfaces:**
+- Consumes: `Profile.is_moderator()` (existiert, delegiert an Badge `can_edit_questions`); `Profile.user` (OneToOne zu `User`, hat `is_staff`).
+- Produces: `Profile.can_moderate() -> bool` — `True` wenn der User `is_staff` ist ODER einen Moderator-Badge (`can_edit_questions=True`) hat.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mathefragen/apps/user/tests/test_permissions.py`:
+
+```python
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from mathefragen.apps.user.models import Badge
+
+
+class CanModerateTestCase(TestCase):
+
+    def test_normal_user_cannot_moderate(self):
+        user = User.objects.create(username='normalo', email='normalo@mail.com')
+        self.assertFalse(user.profile.can_moderate())
+
+    def test_staff_user_can_moderate(self):
+        user = User.objects.create(username='staffie', email='staffie@mail.com')
+        user.is_staff = True
+        user.save()
+        self.assertTrue(user.profile.can_moderate())
+
+    def test_badge_moderator_can_moderate(self):
+        user = User.objects.create(username='modmod', email='modmod@mail.com')
+        badge = Badge.objects.create(name='mod', can_edit_questions=True)
+        user.profile.badges.add(badge)
+        self.assertTrue(user.profile.can_moderate())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test mathefragen.apps.user.tests.test_permissions -v 2`
+Expected: FAIL — `AttributeError: 'Profile' object has no attribute 'can_moderate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mathefragen/apps/user/models.py`, direkt nach der bestehenden `is_moderator`-Methode (die `return self.can_edit_questions()` enthält, ~Zeile 410-412) einfügen:
+
+```python
+    def can_moderate(self):
+        return self.user.is_staff or self.is_moderator()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test mathefragen.apps.user.tests.test_permissions -v 2`
+Expected: PASS (3 Tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mathefragen/apps/user/models.py mathefragen/apps/user/tests/test_permissions.py
+git commit -m "feat(user): add Profile.can_moderate() permission helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DQq5ReKsk6FnLTysGngmcz"
+```
+
+---
+
+## Task 2: View + URL `toggle_question_visibility`
+
+**Files:**
+- Modify: `mathefragen/apps/question/views.py` (neue Funktion, z.B. nach `delete_question`, ~Zeile 391)
+- Modify: `mathefragen/apps/question/urls.py` (Import-Tuple + `urlpatterns`)
+- Test: `mathefragen/apps/question/tests/test_moderation.py` (neu)
+
+**Interfaces:**
+- Consumes: `Profile.can_moderate()` (Task 1); `Question.is_active` (BooleanField); `Question.get_absolute_url()`; `login_required`, `redirect` (bereits in `views.py` importiert).
+- Produces: View `toggle_question_visibility(request, question_id)`; URL-Name `toggle_question_visibility` (kwarg `question_id`). Toggelt `Question.is_active` und redirected zur Frage.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mathefragen/apps/question/tests/test_moderation.py`:
+
+```python
+from django.test import Client, TestCase
+from django.shortcuts import reverse
+from django.contrib.auth.models import User
+
+from mathefragen.apps.user.models import Badge
+from mathefragen.apps.stats.models import GlobalStats
+from ..models import Question
+
+
+class ToggleVisibilityTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='owner', email='owner@mail.com')
+        cls.normal = User.objects.create(username='normal', email='normal@mail.com')
+        cls.staff = User.objects.create(username='staff', email='staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def setUp(self):
+        self.client = Client()
+        self.question = Question.objects.create(
+            title='Test', text='Test', user_id=self.owner.id, is_active=True
+        )
+
+    def _url(self):
+        return reverse('toggle_question_visibility', kwargs={'question_id': self.question.id})
+
+    def test_staff_toggles_visibility_off_then_on(self):
+        self.client.force_login(self.staff)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertFalse(self.question.is_active)
+
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.is_active)
+
+    def test_normal_user_cannot_toggle_visibility(self):
+        self.client.force_login(self.normal)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.is_active)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation -v 2`
+Expected: FAIL — `NoReverseMatch: Reverse for 'toggle_question_visibility' not found`
+
+- [ ] **Step 3: Write minimal implementation — view**
+
+In `mathefragen/apps/question/views.py`, nach `delete_question` (endet ~Zeile 390) einfügen:
+
+```python
+@login_required
+def toggle_question_visibility(request, question_id):
+    question = Question.objects.get(id=question_id)
+
+    if request.user.profile.can_moderate():
+        question.is_active = not question.is_active
+        question.save()
+
+    return redirect(question.get_absolute_url())
+```
+
+- [ ] **Step 4: Register the URL**
+
+In `mathefragen/apps/question/urls.py`:
+
+1. Import-Tuple erweitern — nach `delete_question,` die Zeile hinzufügen:
+   ```python
+       toggle_question_visibility,
+   ```
+2. In `urlpatterns` direkt nach der `delete_question`-Route hinzufügen:
+   ```python
+       path('moderate/<int:question_id>/visibility/', toggle_question_visibility, name='toggle_question_visibility'),
+   ```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation -v 2`
+Expected: PASS (2 Tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mathefragen/apps/question/views.py mathefragen/apps/question/urls.py mathefragen/apps/question/tests/test_moderation.py
+git commit -m "feat(question): add moderator toggle_question_visibility view
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DQq5ReKsk6FnLTysGngmcz"
+```
+
+---
+
+## Task 3: `delete_question`-Gate auf `can_moderate()` erweitern
+
+**Files:**
+- Modify: `mathefragen/apps/question/views.py:379` (im bestehenden `delete_question`)
+- Test: `mathefragen/apps/question/tests/test_moderation.py` (Klasse ergänzen)
+
+**Interfaces:**
+- Consumes: `Profile.can_moderate()` (Task 1); bestehende `delete_question`-Logik.
+- Produces: `delete_question` erlaubt Löschen jetzt auch für `is_staff`-Admins ohne Badge (vorher nur Badge-Moderatoren via `is_moderator`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `mathefragen/apps/question/tests/test_moderation.py` neue Testklasse anhängen:
+
+```python
+class DeleteQuestionAuthTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='del_owner', email='del_owner@mail.com')
+        cls.staff = User.objects.create(username='del_staff', email='del_staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+        cls.other = User.objects.create(username='del_other', email='del_other@mail.com')
+
+    def setUp(self):
+        self.client = Client()
+        # delete_question ruft request.stats.update_total_questions();
+        # die AccountCheckMiddleware setzt request.stats = GlobalStats.objects.last().
+        # Ohne Row waere request.stats None -> AttributeError.
+        GlobalStats.objects.create()
+        self.question = Question.objects.create(
+            title='ToDelete', text='ToDelete', user_id=self.owner.id
+        )
+
+    def _url(self):
+        return reverse('delete_question', kwargs={'question_id': self.question.id})
+
+    def test_staff_admin_can_soft_delete(self):
+        self.client.force_login(self.staff)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.soft_deleted)
+
+    def test_unrelated_normal_user_cannot_delete(self):
+        self.client.force_login(self.other)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertFalse(self.question.soft_deleted)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation.DeleteQuestionAuthTestCase -v 2`
+Expected: FAIL — `test_staff_admin_can_soft_delete` schlägt fehl (`soft_deleted` bleibt `False`), weil das Gate aktuell nur `is_moderator` (Badge) erlaubt.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mathefragen/apps/question/views.py` im `delete_question` die beiden Zeilen (~373 und ~379):
+
+```python
+    is_moderator = request.user.profile.is_moderator()
+    ...
+    elif is_moderator:
+        delete_allowed = True
+```
+
+ändern zu:
+
+```python
+    can_moderate = request.user.profile.can_moderate()
+    ...
+    elif can_moderate:
+        delete_allowed = True
+```
+
+(Die `can_be_deleted`-Zeile und der Owner-Zweig bleiben unverändert.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation.DeleteQuestionAuthTestCase -v 2`
+Expected: PASS (2 Tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mathefragen/apps/question/views.py mathefragen/apps/question/tests/test_moderation.py
+git commit -m "feat(question): allow staff admins to delete via can_moderate gate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DQq5ReKsk6FnLTysGngmcz"
+```
+
+---
+
+## Task 4: Moderations-Panel im Template
+
+**Files:**
+- Modify: `mathefragen/templates/question/question_content.html` (nach dem Aktions-Block, ~Zeile 95, innerhalb `<div class="col-md-11 ...">` aber außerhalb der `{% if question.is_active %}`-Blöcke)
+- Test: `mathefragen/apps/question/tests/test_moderation.py` (Integrations-Testklasse ergänzen)
+
+**Interfaces:**
+- Consumes: `Profile.can_moderate` (Task 1, im Template ohne Klammern); URL-Name `toggle_question_visibility` (Task 2); URL-Name `delete_question` (existiert).
+- Produces: sichtbares Panel mit zwei Buttons nur für Moderatoren.
+
+- [ ] **Step 1: Write the failing test**
+
+In `mathefragen/apps/question/tests/test_moderation.py` neue Testklasse anhängen:
+
+```python
+class ModerationPanelRenderTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='p_owner', email='p_owner@mail.com')
+        cls.normal = User.objects.create(username='p_normal', email='p_normal@mail.com')
+        cls.staff = User.objects.create(username='p_staff', email='p_staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def setUp(self):
+        self.client = Client()
+        # question_detail_hashed ruft request.stats.update_total_questions();
+        # daher GlobalStats-Row noetig (siehe DeleteQuestionAuthTestCase).
+        GlobalStats.objects.create()
+        self.question = Question.objects.create(
+            title='PanelTest', text='PanelTest', user_id=self.owner.id
+        )
+
+    def _visibility_url(self):
+        return reverse('toggle_question_visibility', kwargs={'question_id': self.question.id})
+
+    def test_panel_visible_for_staff(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(self.question.get_absolute_url())
+        self.assertContains(response, self._visibility_url())
+
+    def test_panel_hidden_for_normal_user(self):
+        self.client.force_login(self.normal)
+        response = self.client.get(self.question.get_absolute_url())
+        self.assertNotContains(response, self._visibility_url())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation.ModerationPanelRenderTestCase -v 2`
+Expected: FAIL — `test_panel_visible_for_staff` findet die Visibility-URL nicht im gerenderten HTML.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mathefragen/templates/question/question_content.html` den bestehenden Authentifizierungs-Block bei ~Zeile 81-95 (der die owner/`is_moderator`-„Bearbeiten"-Links enthält) belassen und **unmittelbar danach**, noch vor dem schließenden `</div>` bei Zeile 96, das Panel einfügen:
+
+```django
+                    {% if request.user.is_authenticated and request.user.profile.can_moderate %}
+                        <div class="mod-control-panel mt-1 mb-3">
+                            <small class="text-muted mr-2">Moderation</small>
+                            <a href="{% url 'toggle_question_visibility' question.id %}"
+                               class="btn btn-sm btn-outline-secondary mr-1">
+                                {% if question.is_active %}Verstecken{% else %}Einblenden{% endif %}
+                            </a>
+                            <a href="{% url 'delete_question' question.id %}"
+                               class="btn btn-sm btn-outline-danger"
+                               onclick="return confirm('Diese Frage wirklich löschen?');">
+                                Löschen
+                            </a>
+                        </div>
+                    {% endif %}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation.ModerationPanelRenderTestCase -v 2`
+Expected: PASS (2 Tests)
+
+- [ ] **Step 5: Run full moderation + permission suite**
+
+Run: `python manage.py test mathefragen.apps.question.tests.test_moderation mathefragen.apps.user.tests.test_permissions -v 2`
+Expected: PASS (alle Tests aus Task 1–4)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mathefragen/templates/question/question_content.html mathefragen/apps/question/tests/test_moderation.py
+git commit -m "feat(question): add moderation control panel to question detail
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DQq5ReKsk6FnLTysGngmcz"
+```
+
+---
+
+## Manuelle Verifikation (nach allen Tasks)
+
+1. Als `is_staff`-User (oder Badge-Moderator) eine Frage öffnen → Panel „Moderation" mit **Verstecken** + **Löschen** sichtbar.
+2. **Verstecken** klicken → Seite lädt neu, Antworten/Formular weg, Button heißt jetzt **Einblenden**, Panel weiterhin sichtbar.
+3. **Einblenden** → Frage wieder normal.
+4. **Löschen** → Confirm-Dialog; nach Bestätigung Redirect auf Startseite (`?deleted=1`), Frage nicht mehr in Listen.
+5. Als normaler User dieselbe Frage öffnen → kein Panel.
+
+## Self-Review (vom Plan-Autor durchgeführt)
+
+- **Spec-Coverage:** `can_moderate` (Task 1) ✓ · Verstecken/Einblenden View+URL (Task 2) ✓ · Löschen-Gate erweitert (Task 3) ✓ · Panel-Template (Task 4) ✓ · Tests je Task ✓. Kein `locked`/„Schließen" — bewusst out of scope laut Spec.
+- **Placeholder-Scan:** keine TBD/TODO; jeder Code-Step enthält vollständigen Code + konkrete Kommandos.
+- **Typ-Konsistenz:** URL-Name `toggle_question_visibility` und View-Signatur `(request, question_id)` in Task 2, 4 identisch; `can_moderate()` (View) / `can_moderate` (Template) konsistent; Feldname `is_active`, `soft_deleted` gemäß Model.

--- a/docs/superpowers/specs/2026-07-14-admin-question-moderation-buttons-design.md
+++ b/docs/superpowers/specs/2026-07-14-admin-question-moderation-buttons-design.md
@@ -1,0 +1,150 @@
+# Admin Control Buttons für Fragen-Moderation
+
+**Datum:** 2026-07-14
+**Status:** Design (zur Review)
+
+## Ziel
+
+Admins und Moderatoren sollen direkt auf der Fragen-Detailseite
+(`/frage/q/<hash>/<slug>/`) eine Frage moderieren können, ohne den Umweg über
+den Django-Adminbereich: **verstecken** (öffentlich unsichtbar, reversibel) und
+**löschen**. Anlass: unnötige/Spam-Fragen sollen mit einem Klick weggeräumt
+werden können.
+
+## Scope-Entscheidung
+
+Nur **zwei** Aktionen: Löschen + Verstecken/Einblenden. Ein „Schließen"-Button
+(Frage sichtbar, aber keine neuen Antworten) wurde **bewusst verworfen** — für
+den realen Bedarf („unnötige Frage weg") genügen Löschen und Verstecken. Damit
+entfällt auch das ursprünglich angedachte neue `locked`-Feld inkl. Migration.
+
+## Zielgruppe / Berechtigung
+
+Buttons sind sichtbar und nutzbar für **Admins (`is_staff`) UND Badge-Moderatoren
+(`can_edit_questions`)**.
+
+Dafür eine gebündelte Berechtigungsmethode auf dem Profil, damit Template-Gate
+und View-Check identisch sind:
+
+```python
+# mathefragen/apps/user/models.py  (nahe is_moderator, ~Zeile 410)
+def can_moderate(self):
+    return self.user.is_staff or self.is_moderator()
+```
+
+- Template-Gate: `{% if request.user.is_authenticated and request.user.profile.can_moderate %}`
+- View: Inline-Re-Check `request.user.profile.can_moderate()` (gleiches Muster wie
+  das bestehende `delete_question`, `views.py:373-380`).
+
+## Views (`mathefragen/apps/question/views.py`)
+
+Alle folgen dem bestehenden Muster: `@login_required` + Inline-`can_moderate()`-
+Re-Check + Redirect zurück zur Frage.
+
+1. **Löschen — bestehendes `delete_question` erweitern** (`views.py:369-390`).
+   Autorisierung von `is_moderator` auf `can_moderate()` erweitern:
+   ```python
+   elif request.user.profile.can_moderate():
+       delete_allowed = True
+   ```
+   Rest unverändert (Soft-Delete via `question.delete()`, Redirect Startseite mit
+   `?deleted=1`).
+
+2. **`toggle_question_visibility(request, question_id)` — neu.**
+   ```python
+   @login_required
+   def toggle_question_visibility(request, question_id):
+       question = Question.objects.get(id=question_id)
+       if request.user.profile.can_moderate():
+           question.is_active = not question.is_active
+           question.save()
+       return redirect(question.get_absolute_url())
+   ```
+   Setzt **nur** `is_active` — bewusst **nicht** `make_inactive()` verwenden, da
+   dessen Owner-Mail („…scheint Unstimmigkeiten zu enthalten und wurde gemeldet",
+   `models.py:365-381`) für eine Admin-Aktion inhaltlich falsch wäre.
+
+## URLs (`mathefragen/apps/question/urls.py`)
+
+```python
+path('moderate/<int:question_id>/visibility/', toggle_question_visibility, name='toggle_question_visibility'),
+```
+
+Delete-Route existiert bereits (`delete/<int:question_id>/d/`).
+
+## Template — Moderations-Panel (`mathefragen/templates/question/question_content.html`)
+
+Neuer, optisch abgesetzter Block, gegated auf `can_moderate`, platziert im
+Aktions-Bereich unter Titel/Vote (nahe der bestehenden Aktions-Leiste
+`question_content.html:60-95`). Wichtig: dieser Bereich liegt **außerhalb** der
+`{% if question.is_active %}`-Blöcke — dadurch bleibt das Panel auch bei einer
+versteckten Frage sichtbar, sodass Moderatoren sie wieder einblenden können.
+
+```django
+{% if request.user.is_authenticated and request.user.profile.can_moderate %}
+    <div class="mod-control-panel mt-1 mb-3">
+        <small class="text-muted mr-2">Moderation</small>
+        <a href="{% url 'toggle_question_visibility' question.id %}"
+           class="btn btn-sm btn-outline-secondary mr-1">
+            {% if question.is_active %}Verstecken{% else %}Einblenden{% endif %}
+        </a>
+        <a href="{% url 'delete_question' question.id %}"
+           class="btn btn-sm btn-outline-danger"
+           onclick="return confirm('Diese Frage wirklich löschen?');">
+            Löschen
+        </a>
+    </div>
+{% endif %}
+```
+
+- Verstecken-Label wechselt je nach `is_active`.
+- **Löschen** rot + JS-`confirm()` (destruktiv). Verstecken ohne Confirm (sofort,
+  reversibel).
+- Styling an bestehende Bootstrap-Button-Klassen der Seite angelehnt; finale
+  CSS-Feinheiten im Plan.
+
+## Semantik / bekannte Grenzen
+
+- **Verstecken (`is_active=False`)** entspricht exakt dem bestehenden Report-Hide
+  (`make_inactive`): Frage verschwindet aus Feeds/Listen (die filtern `is_active`),
+  Antworten + Formular werden ausgeblendet, der Fragetext bleibt bei direktem
+  URL-Aufruf im `readonly_content`-Stil sichtbar. Kein hartes 404 für die
+  Öffentlichkeit — das wäre zusätzlicher Scope und weicht vom bestehenden
+  Verhalten ab. Reversibel über „Einblenden".
+- **Löschen** ist ein Soft-Delete (`soft_deleted=True`, `closed=True`). Eine
+  Wiederherstellung ist nur über den Django-Adminbereich möglich (kein
+  Undo-Button auf der Seite).
+- **Security-Hinweis (GET vs. POST):** Die neuen/erweiterten Endpoints folgen dem
+  bestehenden Muster GET-Link ohne CSRF-Token (wie `delete_question`,
+  `delete_answer`). Sauberer wären POST-Forms mit CSRF-Token; das wäre jedoch ein
+  Bruch mit dem restlichen Code und wird hier bewusst zurückgestellt (konsistent
+  statt korrekt). Kann in einem Folge-Schritt für alle Moderations-Endpoints
+  gemeinsam auf POST umgestellt werden.
+
+## Tests (`mathefragen/apps/question/tests*`)
+
+- `can_moderate()`: `is_staff` → True, Badge-Moderator → True, normaler User → False.
+- `toggle_question_visibility`: Moderator schaltet `is_active` um; normaler User
+  bewirkt keine Änderung.
+- `delete_question`: `is_staff`-Admin ohne Badge darf jetzt löschen (erweiterte
+  Autorisierung).
+- Template/Integration: Panel rendert nur für `can_moderate`.
+
+## Betroffene Dateien (Zusammenfassung)
+
+| Datei | Änderung |
+|---|---|
+| `mathefragen/apps/user/models.py` | `Profile.can_moderate()` |
+| `mathefragen/apps/question/views.py` | 1 neue View + `delete_question`-Gate erweitern |
+| `mathefragen/apps/question/urls.py` | 1 neue Route |
+| `mathefragen/templates/question/question_content.html` | Moderations-Panel |
+| `mathefragen/apps/question/tests*` | neue Tests |
+
+## Nicht im Scope (YAGNI)
+
+- „Schließen"-Button / `locked`-Feld.
+- Undo/Restore-Button auf der Seite (Wiederherstellung via Django-Admin).
+- Hartes 404 für versteckte Fragen.
+- Umstellung aller Moderations-Endpoints auf POST/CSRF.
+- Moderations-Log / Audit-Trail.
+- Bulk-Aktionen.

--- a/mathefragen/apps/question/tests/test_moderation.py
+++ b/mathefragen/apps/question/tests/test_moderation.py
@@ -110,3 +110,13 @@ class ModerationPanelRenderTestCase(TestCase):
         self.client.force_login(self.normal)
         response = self.client.get(self.question.get_absolute_url())
         self.assertNotContains(response, self._visibility_url())
+
+    def test_hidden_question_shows_einblenden_for_staff(self):
+        hidden = Question.objects.create(
+            title='HiddenPanelTest', text='HiddenPanelTest',
+            user_id=self.owner.id, is_active=False
+        )
+        self.client.force_login(self.staff)
+        response = self.client.get(hidden.get_absolute_url())
+        self.assertContains(response, reverse('toggle_question_visibility', kwargs={'question_id': hidden.id}))
+        self.assertContains(response, 'Einblenden')

--- a/mathefragen/apps/question/tests/test_moderation.py
+++ b/mathefragen/apps/question/tests/test_moderation.py
@@ -77,3 +77,36 @@ class DeleteQuestionAuthTestCase(TestCase):
         self.client.get(self._url())
         self.question.refresh_from_db()
         self.assertFalse(self.question.soft_deleted)
+
+
+class ModerationPanelRenderTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='p_owner', email='p_owner@mail.com')
+        cls.normal = User.objects.create(username='p_normal', email='p_normal@mail.com')
+        cls.staff = User.objects.create(username='p_staff', email='p_staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def setUp(self):
+        self.client = Client()
+        # question_detail_hashed ruft request.stats.update_total_questions();
+        # daher GlobalStats-Row noetig (siehe DeleteQuestionAuthTestCase).
+        GlobalStats.objects.create()
+        self.question = Question.objects.create(
+            title='PanelTest', text='PanelTest', user_id=self.owner.id
+        )
+
+    def _visibility_url(self):
+        return reverse('toggle_question_visibility', kwargs={'question_id': self.question.id})
+
+    def test_panel_visible_for_staff(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(self.question.get_absolute_url())
+        self.assertContains(response, self._visibility_url())
+
+    def test_panel_hidden_for_normal_user(self):
+        self.client.force_login(self.normal)
+        response = self.client.get(self.question.get_absolute_url())
+        self.assertNotContains(response, self._visibility_url())

--- a/mathefragen/apps/question/tests/test_moderation.py
+++ b/mathefragen/apps/question/tests/test_moderation.py
@@ -41,3 +41,39 @@ class ToggleVisibilityTestCase(TestCase):
         self.client.get(self._url())
         self.question.refresh_from_db()
         self.assertTrue(self.question.is_active)
+
+
+class DeleteQuestionAuthTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='del_owner', email='del_owner@mail.com')
+        cls.staff = User.objects.create(username='del_staff', email='del_staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+        cls.other = User.objects.create(username='del_other', email='del_other@mail.com')
+
+    def setUp(self):
+        self.client = Client()
+        # delete_question ruft request.stats.update_total_questions();
+        # die AccountCheckMiddleware setzt request.stats = GlobalStats.objects.last().
+        # Ohne Row waere request.stats None -> AttributeError.
+        GlobalStats.objects.create()
+        self.question = Question.objects.create(
+            title='ToDelete', text='ToDelete', user_id=self.owner.id
+        )
+
+    def _url(self):
+        return reverse('delete_question', kwargs={'question_id': self.question.id})
+
+    def test_staff_admin_can_soft_delete(self):
+        self.client.force_login(self.staff)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.soft_deleted)
+
+    def test_unrelated_normal_user_cannot_delete(self):
+        self.client.force_login(self.other)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertFalse(self.question.soft_deleted)

--- a/mathefragen/apps/question/tests/test_moderation.py
+++ b/mathefragen/apps/question/tests/test_moderation.py
@@ -1,0 +1,43 @@
+from django.test import Client, TestCase
+from django.shortcuts import reverse
+from django.contrib.auth.models import User
+
+from mathefragen.apps.user.models import Badge
+from mathefragen.apps.stats.models import GlobalStats
+from ..models import Question
+
+
+class ToggleVisibilityTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create(username='owner', email='owner@mail.com')
+        cls.normal = User.objects.create(username='normal', email='normal@mail.com')
+        cls.staff = User.objects.create(username='staff', email='staff@mail.com')
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def setUp(self):
+        self.client = Client()
+        self.question = Question.objects.create(
+            title='Test', text='Test', user_id=self.owner.id, is_active=True
+        )
+
+    def _url(self):
+        return reverse('toggle_question_visibility', kwargs={'question_id': self.question.id})
+
+    def test_staff_toggles_visibility_off_then_on(self):
+        self.client.force_login(self.staff)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertFalse(self.question.is_active)
+
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.is_active)
+
+    def test_normal_user_cannot_toggle_visibility(self):
+        self.client.force_login(self.normal)
+        self.client.get(self._url())
+        self.question.refresh_from_db()
+        self.assertTrue(self.question.is_active)

--- a/mathefragen/apps/question/urls.py
+++ b/mathefragen/apps/question/urls.py
@@ -7,6 +7,7 @@ from .views import (
     question_detail_hashed,
     CreateQuestion,
     delete_question,
+    toggle_question_visibility,
     answer_question,
     accept_answer,
     mark_as_solved_with_tutor,
@@ -31,6 +32,7 @@ urlpatterns = [
 
     path('edit/<int:question_id>/q/', CreateQuestion.as_view(), name='edit_question'),
     path('delete/<int:question_id>/d/', delete_question, name='delete_question'),
+    path('moderate/<int:question_id>/visibility/', toggle_question_visibility, name='toggle_question_visibility'),
     path('answer/<int:question_id>/s/', answer_question, name='answer_question'),
     path('answer/accept/a/', accept_answer, name='accept_answer'),
     path('mark/accept/solved_with_tutor/', mark_as_solved_with_tutor, name='mark_as_solved_with_tutor'),

--- a/mathefragen/apps/question/views.py
+++ b/mathefragen/apps/question/views.py
@@ -370,13 +370,13 @@ def question_detail_hashed(request, hash_id, slug):
 def delete_question(request, question_id):
     question = Question.objects.get(id=question_id)
 
-    is_moderator = request.user.profile.is_moderator()
+    can_moderate = request.user.profile.can_moderate()
     can_be_deleted = question.can_be_deleted()
 
     delete_allowed = False
     if request.user.id == question.user_id and can_be_deleted:
         delete_allowed = True
-    elif is_moderator:
+    elif can_moderate:
         delete_allowed = True
 
     if delete_allowed:

--- a/mathefragen/apps/question/views.py
+++ b/mathefragen/apps/question/views.py
@@ -390,6 +390,17 @@ def delete_question(request, question_id):
     return redirect('%s?question_cant_be_deleted=1' % question.get_absolute_url())
 
 
+@login_required
+def toggle_question_visibility(request, question_id):
+    question = Question.objects.get(id=question_id)
+
+    if request.user.profile.can_moderate():
+        question.is_active = not question.is_active
+        question.save()
+
+    return redirect(question.get_absolute_url())
+
+
 @login_required(login_url='/user/register/')
 def answer_question(request, question_id):
     answer_text = request.POST.get('answer_text')

--- a/mathefragen/apps/user/models.py
+++ b/mathefragen/apps/user/models.py
@@ -411,6 +411,9 @@ class Profile(Base):
         # todo: adjust once badge is refactored
         return self.can_edit_questions()
 
+    def can_moderate(self):
+        return self.user.is_staff or self.is_moderator()
+
     def can_edit_questions(self):
         return bool(self.badges.filter(can_edit_questions=True).count())
 

--- a/mathefragen/apps/user/tests/test_permissions.py
+++ b/mathefragen/apps/user/tests/test_permissions.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from mathefragen.apps.user.models import Badge
+
+
+class CanModerateTestCase(TestCase):
+
+    def test_normal_user_cannot_moderate(self):
+        user = User.objects.create(username='normalo', email='normalo@mail.com')
+        self.assertFalse(user.profile.can_moderate())
+
+    def test_staff_user_can_moderate(self):
+        user = User.objects.create(username='staffie', email='staffie@mail.com')
+        user.is_staff = True
+        user.save()
+        self.assertTrue(user.profile.can_moderate())
+
+    def test_badge_moderator_can_moderate(self):
+        user = User.objects.create(username='modmod', email='modmod@mail.com')
+        badge = Badge.objects.create(name='mod', can_edit_questions=True)
+        user.profile.badges.add(badge)
+        self.assertTrue(user.profile.can_moderate())

--- a/mathefragen/templates/question/question_content.html
+++ b/mathefragen/templates/question/question_content.html
@@ -93,6 +93,20 @@
                             </div>
                         {% endif %}
                     {% endif %}
+                    {% if request.user.is_authenticated and request.user.profile.can_moderate %}
+                        <div class="mod-control-panel mt-1 mb-3">
+                            <small class="text-muted mr-2">Moderation</small>
+                            <a href="{% url 'toggle_question_visibility' question.id %}"
+                               class="btn btn-sm btn-outline-secondary mr-1">
+                                {% if question.is_active %}Verstecken{% else %}Einblenden{% endif %}
+                            </a>
+                            <a href="{% url 'delete_question' question.id %}"
+                               class="btn btn-sm btn-outline-danger"
+                               onclick="return confirm('Diese Frage wirklich löschen?');">
+                                Löschen
+                            </a>
+                        </div>
+                    {% endif %}
                 </div>
                 {% include 'question/includes/question_user_box.html' %}
                 <div class="clearfix"></div>

--- a/mathefragen/templates/question/question_content.html
+++ b/mathefragen/templates/question/question_content.html
@@ -94,7 +94,7 @@
                         {% endif %}
                     {% endif %}
                     {% if request.user.is_authenticated and request.user.profile.can_moderate %}
-                        <div class="mod-control-panel mt-1 mb-3">
+                        <div class="mod-control-panel mt-1 mb-3" style="border: 1px solid #e0e0e0; border-left: 3px solid #dc3545; border-radius: 4px; background-color: #f8f9fa; padding: 8px 12px; display: inline-block;">
                             <small class="text-muted mr-2">Moderation</small>
                             <a href="{% url 'toggle_question_visibility' question.id %}"
                                class="btn btn-sm btn-outline-secondary mr-1">


### PR DESCRIPTION
## Was

Admin-/Moderator-Kontroll-Buttons direkt auf der Fragen-Detailseite. Admins und Moderatoren können eine Frage ohne Umweg über den Django-Adminbereich moderieren — unnötige/Spam-Fragen mit einem Klick wegräumen.

Ein Moderations-Panel (nur für Berechtigte sichtbar) mit zwei Aktionen:
- **Verstecken / Einblenden** — schaltet `Question.is_active` um (öffentlich unsichtbar, reversibel)
- **Löschen** — Soft-Delete via bestehendem Endpoint, mit Bestätigungs-Dialog

## Änderungen

- `Profile.can_moderate()` = `is_staff OR is_moderator()` (Badge) — eine Berechtigungsquelle für Template + Views
- Neue View `toggle_question_visibility` + Route (`moderate/<id>/visibility/`); setzt nur `is_active` (bewusst **nicht** `make_inactive()`, dessen Owner-Mail-Text „…wurde gemeldet" für eine Admin-Aktion falsch wäre)
- `delete_question`-Gate von `is_moderator` auf `can_moderate()` erweitert → `is_staff`-Admins ohne Badge dürfen jetzt löschen
- Moderations-Panel in `question_content.html`, gegated auf `can_moderate`, platziert außerhalb der `{% if question.is_active %}`-Blöcke → bleibt bei versteckter Frage sichtbar (sonst wäre „Einblenden" unerreichbar)

## Bewusste Design-Entscheidungen

- **Kein „Schließen"-Button / kein `locked`-Feld** — im Brainstorming verworfen; für den realen Bedarf genügen Löschen + Verstecken. Keine Migration nötig.
- **GET-Links ohne CSRF** — folgt dem Bestandsmuster (`delete_question`/`delete_answer` sind ebenfalls GET). Umstellung aller Moderations-Endpoints auf POST/CSRF als Folge-Schritt vorgemerkt (siehe Spec).

## Tests

10/10 grün: `DEBUG=True poetry run python manage.py test mathefragen.apps.question.tests.test_moderation mathefragen.apps.user.tests.test_permissions`
- `can_moderate()`: staff / badge-mod / normaler User
- Toggle-Visibility: Mod schaltet um, normaler User nicht
- Delete-Gate: `is_staff`-Admin darf, unbeteiligter User nicht
- Panel-Render: sichtbar für Mod, unsichtbar für normalen User, „Einblenden" bei versteckter Frage

Hinweis: `DEBUG=True` nötig, weil Settings Sessions bei `not DEBUG` zu Redis Sentinel routen (nicht durch `TESTING` gegated) — pre-existing, nicht Teil dieses PRs.

Design-Spec + Implementierungs-Plan liegen unter `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
